### PR TITLE
Fix row duplication caused by aggregation of authors and subjects

### DIFF
--- a/docs/api_data.js
+++ b/docs/api_data.js
@@ -1152,7 +1152,7 @@ define({ "api": [
       "examples": [
         {
           "title": "Success-reponse:",
-          "content": "HTTP/1.1 200 OK\n{ id: 1,\n  title: 'Classical Mechanics Part 2',\n  isbn: '9999999999999',\n  cover_url: 'https://www.uscibooks.com/taycm.jpg',\n  description:\n  'John Taylor has brought to his most recent book, Classical Mechanics, all of the clarity and insight that made his Introduction to Error Analysis a best-selling text.',\n  average: 4.25,\n  edition: '1',\n  year: 2005,\n  featured: false,\n  publisher_id: 1,\n  created_at: null,\n  updated_at: null,\n  subjects: [{}],\n  authors: [{}],\n  publisher: 'University Science Books',\n}",
+          "content": "HTTP/1.1 200 OK\n{ id: 1,\n  title: 'Classical Mechanics Part 2',\n  isbn: '9999999999999',\n  cover_url: 'https://www.uscibooks.com/taycm.jpg',\n  description:\n  'John Taylor has brought to his most recent book, Classical Mechanics, all of the clarity and insight that made his Introduction to Error Analysis a best-selling text.',\n  average: 4.25,\n  edition: '1',\n  year: 2005,\n  featured: false,\n  publisher_id: 1,\n  created_at: null,\n  updated_at: null,\n  subjects: null,\n  authors: null,\n  publisher: 'University Science Books',\n}",
           "type": "json"
         }
       ]

--- a/docs/api_data.json
+++ b/docs/api_data.json
@@ -1152,7 +1152,7 @@
       "examples": [
         {
           "title": "Success-reponse:",
-          "content": "HTTP/1.1 200 OK\n{ id: 1,\n  title: 'Classical Mechanics Part 2',\n  isbn: '9999999999999',\n  cover_url: 'https://www.uscibooks.com/taycm.jpg',\n  description:\n  'John Taylor has brought to his most recent book, Classical Mechanics, all of the clarity and insight that made his Introduction to Error Analysis a best-selling text.',\n  average: 4.25,\n  edition: '1',\n  year: 2005,\n  featured: false,\n  publisher_id: 1,\n  created_at: null,\n  updated_at: null,\n  subjects: [{}],\n  authors: [{}],\n  publisher: 'University Science Books',\n}",
+          "content": "HTTP/1.1 200 OK\n{ id: 1,\n  title: 'Classical Mechanics Part 2',\n  isbn: '9999999999999',\n  cover_url: 'https://www.uscibooks.com/taycm.jpg',\n  description:\n  'John Taylor has brought to his most recent book, Classical Mechanics, all of the clarity and insight that made his Introduction to Error Analysis a best-selling text.',\n  average: 4.25,\n  edition: '1',\n  year: 2005,\n  featured: false,\n  publisher_id: 1,\n  created_at: null,\n  updated_at: null,\n  subjects: null,\n  authors: null,\n  publisher: 'University Science Books',\n}",
           "type": "json"
         }
       ]

--- a/docs/api_project.js
+++ b/docs/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2019-05-23T22:12:56.812Z",
+    "time": "2019-05-23T22:47:51.296Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/docs/api_project.json
+++ b/docs/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2019-05-23T22:12:56.812Z",
+    "time": "2019-05-23T22:47:51.296Z",
     "url": "http://apidocjs.com",
     "version": "0.17.7"
   }

--- a/models/books.spec.js
+++ b/models/books.spec.js
@@ -81,9 +81,9 @@ describe('books model', () => {
                              created_at: null,
                              updated_at: null,
                              average: null,
-                             authors: [{}],
+                             authors: null,
                              reviews: [],
-                             subjects: [{}],
+                             subjects: null,
                              user_review: null,
                            };
       expect(book).toEqual(expectedBook);

--- a/routes/books.js
+++ b/routes/books.js
@@ -182,8 +182,8 @@ router.post('/', restricted, (req, res) => {
      publisher_id: 1,
      created_at: null,
      updated_at: null,
-     subjects: [{}],
-     authors: [{}],
+     subjects: null,
+     authors: null,
      publisher: 'University Science Books',
    }
    

--- a/routes/books.spec.js
+++ b/routes/books.spec.js
@@ -125,9 +125,9 @@ describe('books /api/books', () => {
                              average: null,
                              created_at: null,
                              updated_at: null,
-                             authors: [{}],
+                             authors: null,
                              reviews: [],
-                             subjects: [{}],
+                             subjects: null,
                              user_review: null,
                            };
       expect(body).toEqual(expectedBook);


### PR DESCRIPTION
Moved aggregation into the subquery and join off that, rather than joining and
then aggregating. This also removes the need for a group by and, more logically,
returns null for no authors or subjects rather than [{}].